### PR TITLE
Fix location of time breaks

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,6 +85,10 @@ namespace Search
 
     Value SearchThread::negamax(Value alpha, Value beta, Depth depth, SearchStack *ss)
     {
+        if (limits.stopped)
+        {
+            return 0;
+        }
 
         pvTable.pvLength[ss->ply] = ss->ply;
 
@@ -137,6 +141,11 @@ namespace Search
 
             board.unmakeMove(move);
 
+            if (limits.stopped)
+            {
+                return 0;
+            }
+
             if (value >= bestValue)
             {
                 bestValue = value;
@@ -160,11 +169,6 @@ namespace Search
                         break;
                     }
                 }
-            }
-
-            if (limits.stopped)
-            {
-                return 0;
             }
         }
 


### PR DESCRIPTION
Score of dev vs master: 94 - 24 - 44  [0.716] 162
...      dev playing White: 30 - 23 - 28  [0.543] 81
...      dev playing Black: 64 - 1 - 16  [0.889] 81
...      White vs Black: 31 - 87 - 44  [0.327] 162
Elo difference: 160.7 +/- 48.8, LOS: 100.0 %, DrawRatio: 27.2 %
SPRT: llr 2.97 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match