### PR TITLE
Add optimal time vs max time

### DIFF
--- a/src/timeman.hpp
+++ b/src/timeman.hpp
@@ -43,16 +43,14 @@ namespace Search
                 Time inc = (side == chess::Color::WHITE ? winc : binc);
                 uci_time -= safety_overhead;
 
-                uci_time /= 20;
-
-                Time time_slot = average_time = uci_time + inc;
+                Time time_slot = average_time = uci_time / 20 + inc;
                 Time basetime = (time_slot);
 
                 Time optime = basetime * 0.6;
 
                 Time maxtime = std::min<Time>(uci_time, basetime * 2);
                 stoptime_max = maxtime;
-                stoptime_opt = maxtime;
+                stoptime_opt = optime;
             }
             else if (movetime != TIME_UNSET)
             {


### PR DESCRIPTION
Score of dev vs master: 126 - 35 - 18  [0.754] 179
...      dev playing White: 78 - 7 - 6  [0.890] 91
...      dev playing Black: 48 - 28 - 12  [0.614] 88
...      White vs Black: 106 - 55 - 18  [0.642] 179
Elo difference: 194.8 +/- 55.7, LOS: 100.0 %, DrawRatio: 10.1 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted